### PR TITLE
Update merkle-interval-tree.ts

### DIFF
--- a/packages/core/src/app/block-production/merkle-interval-tree.ts
+++ b/packages/core/src/app/block-production/merkle-interval-tree.ts
@@ -257,7 +257,7 @@ export class GenericMerkleIntervalTree implements MerkleIntervalTree {
           Buffer.compare(right.lowerBound, firstRightSibling.lowerBound) === -1
         ) {
           throw new Error(
-            'Invalid Merkle Index Tree proof--potential intersection detected.'
+            'Invalid Merkle Index Tree proof--leaves are not sorted by lowerBound.'
           )
         }
       }


### PR DESCRIPTION
The error message is not appropriate, it will mislead readers.