### PR TITLE
Update state-interval-tree.ts

### DIFF
--- a/packages/core/src/app/block-production/state-interval-tree.ts
+++ b/packages/core/src/app/block-production/state-interval-tree.ts
@@ -41,7 +41,7 @@ export class MerkleStateIntervalTree extends GenericMerkleIntervalTree {
     // Check that the bound agrees with the end.
     if (stateUpdate.range.end.gt(rootAndBound.upperBound)) {
       throw new Error(
-        'State Update range.end exceeds the max for its inclusion proof.'
+        'Invalid Merkle Index Tree proof--potential intersection detected.'
       )
     }
     return rootAndBound.root


### PR DESCRIPTION
For "the max for its inclusion proof",  this is misleading error message.
In the case, intersection is detected in the tree, so I modified the error message.
